### PR TITLE
Reduce default NumberBox precision to 6 digits

### DIFF
--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -207,8 +207,10 @@ void NumberBox::OnApplyTemplate()
 
     m_isEnabledChangedRevoker = IsEnabledChanged(winrt::auto_revoke, { this,  &NumberBox::OnIsEnabledChanged });
 
-    // .NET rounds to 12 significant digits when displaying doubles, so we will do the same.
-    m_displayRounder.SignificantDigits(12);
+    // printf() defaults to 6 digits. 6 digits are sufficient for most
+    // users under most circumstances, while simultaneously avoiding most
+    // rounding errors for instance during double/float conversion.
+    m_displayRounder.SignificantDigits(6);
 
     UpdateSpinButtonPlacement();
     UpdateSpinButtonEnabled();


### PR DESCRIPTION
## Description
printf() defaults to 6 digits. 6 digits are sufficient for most
users under most circumstances, while simultaneously avoiding most
rounding errors for instance during double/float conversion.

Closes #3959

## Motivation and Context
The previous code says:
> .NET rounds to 12 significant digits when displaying doubles [...]

If one were to be annoyingly pedantic, then this isn't quite true:
.NET defaults to 12 for float-to-string conversions and not for human display.

More importantly however `FLT_DECIMAL_DIG` is 9. With 12 significantly
exceeding this, WinUI is incapable of presenting 32-bit floats.
C defaults to 6 digits for string conversions for this exact reason.

## How Has This Been Tested?
Windows Terminal overrides its NumberBoxes with 6 `SignificantDigits`.

## Screenshots (if appropriate):
Before:
![YraMDjf6wkUTvhKu](https://user-images.githubusercontent.com/2256941/196748211-82f5d842-f6b4-46f0-bec6-a4de6bf8459e.gif)

After:
![bhvRxhZxbeefgMrL](https://user-images.githubusercontent.com/2256941/196748727-b5e46068-927f-4708-9e04-638066e51d1e.gif)